### PR TITLE
API service location usage exception problem fixed

### DIFF
--- a/module/Api/Module.php
+++ b/module/Api/Module.php
@@ -5,6 +5,7 @@ use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\ApiProblemResponse;
+use ZF\MvcAuth\Identity\AuthenticatedIdentity;
 use ZF\MvcAuth\MvcAuthEvent;
 
 class Module
@@ -28,10 +29,32 @@ class Module
     public function onBootstrap(MvcEvent $event)
     {
         $eventManager = $event->getApplication()->getEventManager();
+        $oauth2Closure = $event->getApplication()->getServiceManager()
+                             ->get(\ZF\OAuth2\Service\OAuth2Server::class);
+        $logger = $event->getApplication()->getServiceManager()->get('logger');
+
 
         $eventManager->attach(
             MvcAuthEvent::EVENT_AUTHENTICATION_POST,
-            array($this, 'eventAuthenticationPost'),
+            function (MvcAuthEvent $event) use ($oauth2Closure) {
+                // Manipulating Identity Data
+                $identity      = $event->getIdentity();
+
+                if (!!$identity) {
+                    if ($identity instanceof AuthenticatedIdentity) {
+                        $userData = $oauth2Closure()->getStorage('user_credentials')->getUser($identity->getName());
+                        if (is_array($identity->getAuthenticationIdentity())) {
+                            $userData = array_merge($userData, $identity->getAuthenticationIdentity());
+                        }
+                        $identity = new AuthenticatedIdentity($userData);
+                        $event->setIdentity($identity);
+                    }
+                    //MvcEvent did not understand when manipulated MvcAuthEvent identity
+                    $event->getMvcEvent()->setParam('ZF\MvcAuth\Identity', $identity);
+                }
+
+                return $event;
+            },
             900
         );
 
@@ -40,73 +63,43 @@ class Module
 
         $event->getApplication()->getEventManager()->attach(
             MvcEvent::EVENT_DISPATCH_ERROR,
-            array($this, 'dispatchError'),
+            function (MvcEvent $event) use ($logger) {
+                $problem = null;
+                if ($event->isError()) {
+                    $exception = $event->getParam("exception");
+
+                    // There are some other errors like that :
+                    // "error-controller-cannot-dispatch",
+                    // "error-controller-invalid",
+                    // "error-controller-not-found",
+                    // "error-router-no-match",
+                    if ($event->getError() === 'error-controller-not-found') {
+                        $problem = new ApiProblem(404, "Endpoint controller not found!");
+                    } elseif ($event->getError() === 'error-router-no-match') {
+                        $problem = new ApiProblem(404, "Not found!");
+                    } elseif ($exception instanceof \Exception) {
+                        $className = explode('\\', get_class($exception));
+                        $problem   = new ApiProblem($exception->getCode(), end($className) . ' error.');
+
+                        $logger->err($exception->getMessage(), array(
+                            'controller' => $event->getControllerClass(),
+                        ));
+                    }
+                } else {
+                    $problem = new ApiProblem(500, "Unknown Error!");
+                }
+
+                $response = new ApiProblemResponse($problem);
+                $event->stopPropagation();
+
+                return $response;
+            },
             9000
         );
     }
 
-    public function eventAuthenticationPost(MvcAuthEvent $event)
-    {
-        // Manupilating Identity Data
-        $identity      = $event->getIdentity();
-        $oauth2Closure = $event->getMvcEvent()
-                               ->getApplication()
-                               ->getServiceManager()
-                               ->get(\ZF\OAuth2\Service\OAuth2Server::class);
-
-        if (!!$identity) {
-            if ($identity instanceof \ZF\MvcAuth\Identity\AuthenticatedIdentity) {
-                $userData = $oauth2Closure()->getStorage('user_credentials')->getUser($identity->getName());
-                if (is_array($identity->getAuthenticationIdentity())) {
-                    $userData = array_merge($userData, $identity->getAuthenticationIdentity());
-                }
-                $identity = new \ZF\MvcAuth\Identity\AuthenticatedIdentity($userData);
-                $event->setIdentity($identity);
-            }
-            //MvcEvent did not understand when manipulated MvcAuthEvent identity
-            $event->getMvcEvent()->setParam('ZF\MvcAuth\Identity', $identity);
-        }
-
-        return $event;
-    }
-
     public function dispatchError(MvcEvent $event)
     {
-        $problem = null;
-        if ($event->isError()) {
-            $exception = $event->getParam("exception");
-            
-            // There are some other errors like that :
-                // "error-controller-cannot-dispatch",
-                // "error-controller-invalid",
-                // "error-controller-not-found",
-                // "error-router-no-match",
-            if ($event->getError() === 'error-controller-not-found') {
-                $problem = new ApiProblem(404, "Endpoint controller not found!");
-            } elseif ($event->getError() === 'error-router-no-match') {
-                $problem = new ApiProblem(404, "Not found!");
-            } elseif ($exception instanceof \Exception) {
-                $className = explode('\\', get_class($exception));
-                $problem   = new ApiProblem($exception->getCode(), end($className) . ' error.');
 
-                if ($event->getTarget() instanceof ServiceLocatorAwareInterface) {
-                    $logger    = $event->getTarget()->getServiceLocator()->get('logger');
-                } else {
-                    $logger    = $event->getTarget()->getServiceManager()->get('logger');
-                }
-
-                $logger    = $event->getTarget()->getServiceManager()->get('logger');
-                $logger->err($exception->getMessage(), array(
-                    'controller' => $event->getControllerClass(),
-                    ));
-            }
-        } else {
-            $problem = new ApiProblem(500, "Unknown Error!");
-        }
-        
-        $response = new ApiProblemResponse($problem);
-        $event->stopPropagation();
-
-        return $response;
     }
 }


### PR DESCRIPTION
There is a problem at `module/Api/src/Api/Module.php:52` file. which is  We use following lines to get OAuth2Server from serviceManager but it was not correct way to fetch from directly serviceManager. We must change it because AbstractPluginManager is throwing `Exception\ServiceLocatorUsageException` excepiton.

```
$oauth2Closure = $event->getMvcEvent()
                               ->getApplication()
                               ->getServiceManager()
                               ->get(\ZF\OAuth2\Service\OAuth2Server::class);
```

This pr fix the problem. 